### PR TITLE
Convert shipping ad strings to floats

### DIFF
--- a/src/ShippingAds.ts
+++ b/src/ShippingAds.ts
@@ -14,9 +14,9 @@ export class ShippingAds {
       const matches = text && text.match(/(?:SHIPPING)\s([\d.]+)t\s\/\s([\d.]+)m³\s@\s([\d,.]+)\s[A-Z]+\sfrom/);
 
       if (matches && matches.length > 3) {
-        const totalCost = matches[3];
-        const tonnage = matches[1];
-        const size = matches[2];
+        const totalCost = parseFloat(matches[3]);
+        const tonnage = parseFloat(matches[1]);
+        const size = parseFloat(matches[2]);
         var unit;
         var count;
         if(tonnage > size){

--- a/src/ShippingAds.ts
+++ b/src/ShippingAds.ts
@@ -14,7 +14,7 @@ export class ShippingAds {
       const matches = text && text.match(/(?:SHIPPING)\s([\d.]+)t\s\/\s([\d.]+)m³\s@\s([\d,.]+)\s[A-Z]+\sfrom/);
 
       if (matches && matches.length > 3) {
-        const totalCost = parseFloat(matches[3]);
+        const totalCost = matches[3];
         const tonnage = parseFloat(matches[1]);
         const size = parseFloat(matches[2]);
         var unit;


### PR DESCRIPTION
You currently have a bug in ShippingAds where tonnage and size are compared as strings. This means that these values are compared lexicographically instead of numerically (ex: "80.00" is greater lexicographically than "100.00"). 

I just wrapped the string values with `parseFloat` which should mitigate this issue.